### PR TITLE
Introduce option to skip scss generation

### DIFF
--- a/.helper_scripts/build_release.bat
+++ b/.helper_scripts/build_release.bat
@@ -1,0 +1,3 @@
+dotnet build -c Release /p:SourceLinkCreate=true /p:VersionSuffix= /p:OfficialBuild=true
+
+dotnet pack -c Release /p:SourceLinkCreate=true /p:VersionSuffix= /p:OfficialBuild=true

--- a/Bionic/Commands/GenerateComponentCmd.cs
+++ b/Bionic/Commands/GenerateComponentCmd.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using BionicCore;
 using BionicPlugin;
 using McMaster.Extensions.CommandLineUtils;
@@ -9,6 +10,9 @@ namespace BionicCLI.Commands {
   public class GenerateComponentCmd : CommandBase, ICommand {
     [Argument(0, Description = "Artifact Name"), Required]
     private string Artifact { get; set; }
+
+    [Option("-n|--no-styles", Description = "Do not generate component style file")]
+    private bool noStyles { get; set; } = false;
 
     public GenerateCommand Parent { get; }
 
@@ -22,8 +26,10 @@ namespace BionicCLI.Commands {
 
     private int GenerateComponent() {
       Logger.Success($"Generating a component named {Artifact}");
-      DotNetHelper.RunDotNet("new bionic.component -n {Artifact} -o " + ToOSPath("./Components"));
-      return GenerateCommand.IntroduceAppCssImport("Components", Artifact);
+      var dest = ToOSPath("./Components");
+      DotNetHelper.RunDotNet($"new bionic.component -n {Artifact} -o {dest}");
+      if (noStyles) File.Delete($"{dest}/{Artifact}.scss");
+      return noStyles ? 0 : GenerateCommand.IntroduceAppCssImport("Components", Artifact);
     }
   }
 }

--- a/Bionic/Commands/GenerateLayoutCmd.cs
+++ b/Bionic/Commands/GenerateLayoutCmd.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using BionicCore;
 using BionicPlugin;
 using McMaster.Extensions.CommandLineUtils;
@@ -9,6 +10,9 @@ namespace BionicCLI.Commands {
   public class GenerateLayoutCmd : CommandBase, ICommand {
     [Argument(0, Description = "Artifact Name"), Required]
     private string Artifact { get; set; }
+
+    [Option("-n|--no-styles", Description = "Do not generate page style file")]
+    private bool noStyles { get; set; } = false;
 
     public GenerateCommand Parent { get; }
 
@@ -22,8 +26,10 @@ namespace BionicCLI.Commands {
 
     private int GenerateLayout() {
       Logger.Success($"Generating a layout named {Artifact}");
-      DotNetHelper.RunDotNet("new bionic.layout -n {Artifact} -o " + ToOSPath("./Layouts"));
-      return GenerateCommand.IntroduceAppCssImport("Layouts", Artifact);
+      var dest = ToOSPath("./Layouts");
+      DotNetHelper.RunDotNet($"new bionic.layout -n {Artifact} -o {dest}");
+      if (noStyles) File.Delete($"{dest}/{Artifact}.scss");
+      return noStyles ? 0 : GenerateCommand.IntroduceAppCssImport("Layouts", Artifact);
     }
   }
 }

--- a/Bionic/Commands/GeneratePageCmd.cs
+++ b/Bionic/Commands/GeneratePageCmd.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using BionicCore;
 using BionicPlugin;
 using McMaster.Extensions.CommandLineUtils;
@@ -9,6 +10,9 @@ namespace BionicCLI.Commands {
   public class GeneratePageCmd : CommandBase, ICommand {
     [Argument(0, Description = "Artifact Name"), Required]
     private string Artifact { get; set; }
+
+    [Option("-n|--no-styles", Description = "Do not generate page style file")]
+    private bool noStyles { get; set; } = false;
 
     public GenerateCommand Parent { get; }
 
@@ -22,9 +26,11 @@ namespace BionicCLI.Commands {
 
     private int GeneratePage() {
       Logger.Success($"Generating a page named {Artifact}");
+      var dest = ToOSPath("./Pages");
       DotNetHelper.RunDotNet(
-        $"new bionic.page -n {Artifact} -p /{GenerateCommand.ToPageName(Artifact)} -o " + ToOSPath("./Pages"));
-      return GenerateCommand.IntroduceAppCssImport("Pages", Artifact);
+        $"new bionic.page -n {Artifact} -p /{GenerateCommand.ToPageName(Artifact)} -o {dest}");
+      if (noStyles) File.Delete($"{dest}/{Artifact}.scss");
+      return noStyles ? 0 : GenerateCommand.IntroduceAppCssImport("Pages", Artifact);
     }
   }
 }


### PR DESCRIPTION
- Added option -n|--no-styles that prevents scss from being added to the project

Example usage:
bionic generate component MyComponent --no-styles
bionic generate component MyComponent -n

Issue #1